### PR TITLE
feat: support UCIDs in pretense top 10 report

### DIFF
--- a/plugins/pretense/reports.py
+++ b/plugins/pretense/reports.py
@@ -1,5 +1,8 @@
-from core import report, Server, Side, get_translation
 from datetime import datetime
+
+import discord
+
+from core import Server, Side, get_translation, report, utils
 
 from .const import PRETENSE_RANKS
 
@@ -89,10 +92,23 @@ class Top10Pilots(report.EmbedElement):
         xp = ''
         ranks = ''
         for rank, (player, score) in enumerate(sorted_players[:10], start=1):
-            names += f'{player}\n'
+            names += f'{await self._player_name(player)}\n'
             xp += f'{score:>5}\n'
             ranks += f'{self.get_rank(score)}\n'
         if names:
             self.embed.add_field(name=_('Name'), value=names)
             self.embed.add_field(name=_('XP'), value=xp)
             self.embed.add_field(name=_('Rank'), value=ranks)
+
+    async def _player_name(self, player: str) -> str:
+        # if `player` is a UCID, try to mention their discord username
+        # if we can't mention them but can find their name, use that
+        # else fallback to the raw player name/UCID
+        if utils.is_ucid(player):
+            name = await self.bot.get_member_or_name_by_ucid(player)
+            if isinstance(name, discord.Member):
+                return name.mention
+            elif name is not None:
+                return name
+
+        return player


### PR DESCRIPTION
on the BSC servers we run a modified version of pretense that, among other things, stores player progress by UCID instead of name.

as a result of that change, the top 10 pilots report also needed an update to support displaying players by UCID.

i've implemented this in a way that should keep the current behaviour for normal pretense servers, but optionally support UCIDs if they are present.

let me know what you think!

preview:
<img width="438" height="343" alt="image" src="https://github.com/user-attachments/assets/101bc1cd-c277-4c60-a690-ed4ad6d74129" />
(those three broken mentions are not caused by the bot; discord only displays mentions in embeds for users that are already in the client cache. they do populate eventually, as the cache fills up.)