### PR TITLE
Fix: Convert `wind_direction` to int to avoid Pydantic validation error

### DIFF
--- a/plugins/restapi/commands.py
+++ b/plugins/restapi/commands.py
@@ -929,10 +929,11 @@ class RestAPI(Plugin):
             clouds_data = weather_data.get('clouds', {})
             
             # Map DCS weather data to our model using actual structure
+            wind_dir = wind_data.get('dir')
             return WeatherInfo(
                 temperature=weather_data.get('season', {}).get('temperature'),
                 wind_speed=wind_data.get('speed'),
-                wind_direction=wind_data.get('dir'),
+                wind_direction=int(wind_dir) if wind_dir is not None else None,
                 pressure=weather_data.get('qnh'),  # QNH pressure in mmHg
                 visibility=weather_data.get('visibility', {}).get('distance'),  # Extract distance from visibility dict
                 clouds_base=clouds_data.get('base'),


### PR DESCRIPTION
## Problem

The REST API's `get_weather_info` endpoint was failing with recurring Pydantic validation errors:

```
Failed to get weather info for server VEAF (www.veaf.org) [fr] - Private Foothold 2:
1 validation error for WeatherInfo
wind_direction
  Input should be a valid integer, got a number with a fractional part
  [type=int_from_float, input_value=240.99997522634, input_type=float]
```

DCS returns `wind_direction` as a float (e.g. `240.99997522634`), but the `WeatherInfo` Pydantic model declares `wind_direction: int | None`. Pydantic v2 in strict-ish mode rejects floats with fractional parts when an `int` is expected, causing every weather info request to fail.

## Fix

Explicitly cast the `dir` value from DCS weather data to `int` before passing it to the `WeatherInfo` model, with a `None` guard to preserve optionality.

```python
wind_dir = wind_data.get('dir')
wind_direction=int(wind_dir) if wind_dir is not None else None,
```

## Changes

- `plugins/restapi/commands.py`: Extract `wind_dir` and convert to `int` before constructing `WeatherInfo`