### PR TITLE
fix(lotatc): infinite update loop and WinError 5 in schedule()

### DIFF
--- a/extensions/lotatc/extension.py
+++ b/extensions/lotatc/extension.py
@@ -384,9 +384,11 @@ class LotAtc(InstallableExtension, FileSystemEventHandler):
             return
         try:
             version = await self.get_latest_version()
-            if version != self.version:
+            installed = self.get_inst_version()[1]
+            if version != installed:
                 self.log.info(f"A new LotAtc update is available. Updating to version {version} ...")
                 await asyncio.to_thread(self.do_update)
+                installed = self.get_inst_version()[1]
                 self.log.info("LotAtc updated.")
                 bus = ServiceRegistry.get(ServiceBus)
                 await bus.send_to_node({
@@ -428,6 +430,8 @@ class LotAtc(InstallableExtension, FileSystemEventHandler):
                         "method": "send_message",
                         "params": params
                     })
+            if installed != self.version and not self.is_running():
+                await self.update_instance(True)
         except Exception as ex:
             self.log.error(f"LotAtc update failed: {ex}")
 


### PR DESCRIPTION
Fixes #150.

`schedule()` was comparing the latest available version against `self.version` (the instance DLL) but never calling `update_instance()` to copy the updated files across. Since the instance version never changes, the condition stays `True` every 30 minutes → infinite update loop.

A second issue: calling `update_instance()` while LotAtc is running fails with `WinError 5` (Access Denied) because `uninstall()` tries to delete the loaded DLL.

Fix: compare against the base installation version (`get_inst_version()`) instead of the instance. Then only sync the instance when `not self.is_running()` — otherwise `prepare()` handles it safely on the next startup.