### PR TITLE
Add greenieboard functionality to traps endpoint

### DIFF
--- a/plugins/restapi/commands.py
+++ b/plugins/restapi/commands.py
@@ -21,7 +21,7 @@ from services.webservice import WebService
 from typing import Any, Literal, cast
 
 from .models import (TopKill, ServerInfo, SquadronInfo, Trueskill, Highscore, UserEntry, WeaponPK, PlayerStats,
-                     CampaignCredits, TrapEntry, SquadronCampaignCredit, LinkMeResponse, ServerStats, PlayerInfo,
+                     CampaignCredits, TrapEntry, GreenieboardEntry, GreenieboardResponse, SquadronCampaignCredit, LinkMeResponse, ServerStats, PlayerInfo,
                      PlayerSquadron, LeaderBoard, ModuleStats, PlayerEntry, WeatherInfo, ServerAttendanceStats,
                      AirbasesResponse, AirbaseInfoResponse, AirbaseWarehouseResponse, AirbaseSetWarehouseItemResponse,
                      AirbaseCaptureResponse, ConvertCoordinates, MissionRestartResponse, MissionLoadResponse,
@@ -302,8 +302,8 @@ class RestAPI(Plugin):
         self.router.add_api_route(
             "/traps", self.traps,
             methods = ["POST"],
-            response_model = list[TrapEntry],
-            description = "Get traps for players",
+            response_model = list[TrapEntry] | GreenieboardResponse,
+            description = "Get traps for players or the full greenieboard (all traps when nick is omitted)",
             summary = "Carrier Traps",
             tags = ["Statistics"]
         )
@@ -1934,7 +1934,7 @@ class RestAPI(Plugin):
                     )
                 return CampaignCredits.model_validate(row)
 
-    async def traps(self, nick: str = Form(None), date: str | None = Form(None),
+    async def traps(self, nick: str | None = Form(None), date: str | None = Form(None),
                     limit: int | None = Form(10), offset: int | None = Form(0),
                     server_name: str | None = Form(None)):
         self.log.debug(f'Calling /traps with nick="{nick}", date="{date}", server_name="{server_name}"')
@@ -1942,16 +1942,72 @@ class RestAPI(Plugin):
         # Use centralized server resolution
         resolved_server_name, _ = self.get_resolved_server(server_name)
         
-        if resolved_server_name:
-            join = "JOIN missions m ON t.mission_id = m.id"
-            where = "WHERE t.player_ucid = %(ucid)s AND m.server_name = %(server_name)s"
-        else:
-            join = ""
-            where = "WHERE t.player_ucid = %(ucid)s"
+        # If no nick provided, return greenieboard (all traps grouped by player)
+        if not nick:
+            try:
+                async with self.apool.connection() as conn:
+                    async with conn.cursor(row_factory=dict_row) as cursor:
+                        if resolved_server_name:
+                            extra_join = "JOIN missions m ON t.mission_id = m.id"
+                            where = "WHERE m.server_name = %(server_name)s"
+                        else:
+                            extra_join = ""
+                            where = ""
+                        
+                        await cursor.execute(f"""
+                            SELECT p.name AS nick, t.id, t.unit_type, t.grade, t.comment, t.place, 
+                                   t.trapcase, t.wire, t.night, t.points, t.time
+                            FROM traps t
+                            JOIN players p ON t.player_ucid = p.ucid
+                            {extra_join}
+                            {where}
+                            ORDER BY p.name, t.time DESC
+                        """, {"server_name": resolved_server_name})
+                        rows = await cursor.fetchall()
+                
+                # Group traps by player name
+                traps_by_nick: dict[str, list[TrapEntry]] = {}
+                for row in rows:
+                    player_nick = row['nick']
+                    if player_nick not in traps_by_nick:
+                        traps_by_nick[player_nick] = []
+                    traps_by_nick[player_nick].append(TrapEntry.model_validate({
+                        "id": row['id'],
+                        "unit_type": row['unit_type'],
+                        "grade": row['grade'],
+                        "comment": row['comment'],
+                        "place": row['place'],
+                        "trapcase": row['trapcase'],
+                        "wire": row['wire'],
+                        "night": row['night'],
+                        "points": row['points'],
+                        "time": row['time']
+                    }))
+                
+                # Return as GreenieboardResponse with players grouped by nick
+                return GreenieboardResponse(
+                    players=[
+                        GreenieboardEntry(
+                            nick=player_nick,
+                            traps=player_traps
+                        )
+                        for player_nick, player_traps in traps_by_nick.items()
+                    ]
+                )
+            except UndefinedTable:
+                raise HTTPException(status_code=500, detail="Greenieboard is not active on this server")
+        
+        # Nick provided - return traps for that specific player (original behavior)
         try:
             async with self.apool.connection() as conn:
                 async with conn.cursor(row_factory=dict_row) as cursor:
                     ucid = await self.get_ucid(nick, date)
+                    if resolved_server_name:
+                        join = "JOIN missions m ON t.mission_id = m.id"
+                        where = "WHERE t.player_ucid = %(ucid)s AND m.server_name = %(server_name)s"
+                    else:
+                        join = ""
+                        where = "WHERE t.player_ucid = %(ucid)s"
                     await cursor.execute(f"""
                         SELECT t.id, t.unit_type, t.grade, t.comment, t.place, t.trapcase, t.wire, t.night, t.points, t.time
                         FROM traps t

--- a/plugins/restapi/models.py
+++ b/plugins/restapi/models.py
@@ -514,6 +514,15 @@ class TrapEntry(BaseModel):
     }
 
 
+class GreenieboardEntry(BaseModel):
+    nick: str = Field(..., description="Player name")
+    traps: list[TrapEntry] = Field(..., description="List of traps for this player")
+
+
+class GreenieboardResponse(BaseModel):
+    players: list[GreenieboardEntry] = Field(..., description="All players and their traps")
+
+
 class EventEntry(BaseModel):
     mission_id: int = Field(..., description="Mission ID")
     event: str = Field(..., description="Event type")


### PR DESCRIPTION
- Introduced GreenieboardEntry and GreenieboardResponse models to support grouping traps by player.
- Updated traps API route to return full greenieboard when no player nickname is provided.

SINGLE RETURN (NICK PROVIDED):
```json
[
  {
    "id": 28,
    "unit_type": "FA-18C_hornet",
    "grade": "--",
    "comment": "_WUF_HX _F_HLULIM  _F_HLULIC LULAR (LL)IW (NESA)",
    "place": "Rosevelt",
    "trapcase": 1,
    "wire": 4,
    "night": false,
    "points": 2,
    "time": "2026-03-09T23:30:36.392411"
  },
  {
    "id": 27,
    "unit_type": "FA-18C_hornet",
    "grade": "(OK)",
    "comment": "WUF(LOOS)X F(LO)LULIM  F(H)LULIC (H)LULAR  LIG",
    "place": "Rosevelt",
    "trapcase": 1,
    "wire": 4,
    "night": false,
    "points": 3,
    "time": "2026-03-09T23:20:55.901818"
  }
]
```


GREENIEBOARD (NO NICK PROVIDED):
```json
{
  "players": [
    {
      "nick": "GTFO | Big Mac",
      "traps": [
        {
          "id": 83,
          "unit_type": "FA-18C_hornet",
          "grade": "WO",
          "comment": "LIG",
          "place": "Rosevelt",
          "trapcase": 1,
          "wire": null,
          "night": false,
          "points": 1,
          "time": "2026-05-06T03:29:08.728665"
        },
        {
          "id": 82,
          "unit_type": "FA-18C_hornet",
          "grade": "B",
          "comment": "(AASLO)LOX LULIM  (H)IC (H)AR  LIG",
          "place": "Rosevelt",
          "trapcase": 1,
          "wire": null,
          "night": false,
          "points": 2,
          "time": "2026-05-06T03:27:46.895811"
        }
      ]
    },
    {
      "nick": "GTFO | Flash",
      "traps": [
        {
          "id": 80,
          "unit_type": "F-14A-135-GR",
          "grade": "--",
          "comment": "_F_LOOSX _F_(LO)LURIM  _F_(LOLUL)DLIC (F)LO(LUL)AR (LR)IW (LIG)",
          "place": "Rosevelt",
          "trapcase": 1,
          "wire": 3,
          "night": false,
          "points": 2,
          "time": "2026-05-06T03:21:53.911709"
        }
      ]
    },
    {
      "nick": "GTFO | Schilly",
      "traps": [
        {
          "id": 28,
          "unit_type": "FA-18C_hornet",
          "grade": "--",
          "comment": "_WUF_HX _F_HLULIM  _F_HLULIC LULAR (LL)IW (NESA)",
          "place": "Rosevelt",
          "trapcase": 1,
          "wire": 4,
          "night": false,
          "points": 2,
          "time": "2026-03-09T23:30:36.392411"
        }
      ]
    }
  ]
}
```