### PR TITLE
ENHANCEMENTS: - RestAPI: add attendance PlayerCards mode

### DIFF
--- a/plugins/restapi/README.md
+++ b/plugins/restapi/README.md
@@ -36,7 +36,7 @@ The following commands are available through the API
 |--------------------|------------|-------------------------------------------------------|----------------------------------------------------------------------------------------------|
 | /serverstats       | GET        |                                                       | A comprehensive statistic for your whole setup.                                              |
 | /servers           | GET        |                                                       | Status for each server, including weather information if enabled.                            |
-| /server_attendance | GET        | [server_name: string]                                 | Comprehensive server attendance statistics, top theatres/missions/modules, and daily trends. |
+| /server_attendance | GET        | [server_name: string], [PlayerCards: bool]            | Comprehensive statistics, or attendance-card counts only when `PlayerCards=true`.             |
 | /getuser           | POST       | nick: string                                          | Return a list of players ordered by last seen that match this nick.                          |
 | /stats             | POST       | nick: string, date: date                              | Statistics of this player                                                                    |
 | /highscore         | GET        | [server_name: string], [period: string], [limit: int] | Highscore output                                                                             |
@@ -88,6 +88,24 @@ The `/server_attendance` endpoint provides comprehensive server attendance analy
 ```bash
 GET /server_attendance
 ```
+
+**Player-card counts (global or server-specific):**
+```bash
+GET /server_attendance?PlayerCards=true
+GET /server_attendance?server_name=foothold2_server&PlayerCards=true
+```
+
+PlayerCards mode performs only the attendance-count query and returns:
+```json
+{
+  "current_players": 0,
+  "unique_players_24h": 4,
+  "unique_players_7d": 28,
+  "unique_players_30d": 62
+}
+```
+
+Omitting `PlayerCards`, or setting `PlayerCards=false`, returns the normal comprehensive response.
 
 **Server-specific statistics (using DCS server name):**
 ```bash

--- a/plugins/restapi/commands.py
+++ b/plugins/restapi/commands.py
@@ -42,6 +42,7 @@ from .models import (
     ModuleStats,
     PlayerEntry,
     WeatherInfo,
+    ServerAttendancePlayerCards,
     ServerAttendanceStats,
     AirbasesResponse,
     AirbaseInfoResponse,
@@ -197,8 +198,8 @@ class RestAPI(Plugin):
         self.router.add_api_route(
             "/server_attendance", self.server_attendance,
             methods = ["GET"],
-            response_model = ServerAttendanceStats,
-            description = "Get detailed server attendance statistics",
+            response_model = ServerAttendanceStats | ServerAttendancePlayerCards,
+            description = "Get detailed server attendance statistics, or player-card counts only when PlayerCards=true",
             summary = "Server Attendance Statistics", 
             tags = ["Info"]
         )
@@ -1160,9 +1161,13 @@ class RestAPI(Plugin):
                 serverstats['daily_players'] = await cursor.fetchall()
         return ServerStats.model_validate(serverstats)
 
-    async def server_attendance(self, server_name: str = Query(default=None)):
+    async def server_attendance(
+            self,
+            server_name: str = Query(default=None),
+            player_cards: bool = Query(default=False, alias="PlayerCards")
+    ) -> ServerAttendanceStats | ServerAttendancePlayerCards:
         """Get detailed server attendance statistics using monitoring infrastructure patterns"""
-        self.log.debug(f'Calling /server_attendance with server_name = {server_name}')
+        self.log.debug(f'Calling /server_attendance with server_name = {server_name}, PlayerCards = {player_cards}')
         
         # Resolve server name alias to actual name
         resolved_server_name = self.resolve_server_name(server_name)
@@ -1182,6 +1187,31 @@ class RestAPI(Plugin):
 
         async with self.apool.connection() as conn:
             async with conn.cursor(row_factory=dict_row) as cursor:
+                if player_cards:
+                    await cursor.execute(f"""
+                        SELECT
+                            COUNT(DISTINCT s.player_ucid) FILTER (
+                                WHERE s.hop_on > (now() AT TIME ZONE 'utc') - interval '24 hours'
+                            ) AS unique_players_24h,
+                            COUNT(DISTINCT s.player_ucid) FILTER (
+                                WHERE s.hop_on > (now() AT TIME ZONE 'utc') - interval '7 days'
+                            ) AS unique_players_7d,
+                            COUNT(DISTINCT s.player_ucid) FILTER (
+                                WHERE s.hop_on > (now() AT TIME ZONE 'utc') - interval '30 days'
+                            ) AS unique_players_30d
+                        FROM statistics s
+                        JOIN missions m ON m.id = s.mission_id
+                        WHERE s.hop_off IS NOT NULL
+                        {where_clause}
+                    """, params)
+                    row = await cursor.fetchone() or {}
+                    return ServerAttendancePlayerCards(
+                        current_players=current_players,
+                        unique_players_24h=int(row.get('unique_players_24h') or 0),
+                        unique_players_7d=int(row.get('unique_players_7d') or 0),
+                        unique_players_30d=int(row.get('unique_players_30d') or 0)
+                    )
+
                 # Get basic statistics for different periods using monitoring plugin pattern
                 periods = {
                     '24h': "s.hop_on > (now() AT TIME ZONE 'utc') - interval '24 hours'",

--- a/plugins/restapi/models.py
+++ b/plugins/restapi/models.py
@@ -628,6 +628,26 @@ class TopModule(BaseModel):
     unique_players: int
     total_uses: int
 
+
+class ServerAttendancePlayerCards(BaseModel):
+    """Player counts used by the dashboard attendance cards."""
+    current_players: int = Field(..., description="Current number of active players")
+    unique_players_24h: int = Field(..., description="Unique players in last 24 hours")
+    unique_players_7d: int = Field(..., description="Unique players in last 7 days")
+    unique_players_30d: int = Field(..., description="Unique players in last 30 days")
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "current_players": 0,
+                "unique_players_24h": 4,
+                "unique_players_7d": 28,
+                "unique_players_30d": 62
+            }
+        }
+    }
+
+
 class ServerAttendanceStats(BaseModel):
     """Server attendance statistics using monitoring plugin patterns"""
     current_players: int = Field(..., description="Current number of active players")


### PR DESCRIPTION
## Description

Adds an optimized `PlayerCards` mode to the `/server_attendance` REST API endpoint.

### Global attendance

```http
GET /server_attendance?PlayerCards=true
```

### Server-specific attendance

```http
GET /server_attendance?server_name=SERVER_NAME&PlayerCards=true
```

The response contains only the values required by the dashboard’s attendance cards:

```json
{
  "current_players": 0,
  "unique_players_24h": 4,
  "unique_players_7d": 28,
  "unique_players_30d": 62
}
```

## Performance

`PlayerCards` mode uses one count-only database query. It avoids calculating unnecessary:

- Playtime statistics
- Discord engagement
- Daily trends
- Top theatres
- Top missions
- Top modules
- Combat statistics

## Backward Compatibility

- Omitting `PlayerCards` preserves the existing comprehensive response.
- `PlayerCards=false` preserves the existing comprehensive response.
- Global and server-specific filtering continue to work.
- Instance aliases and full DCS server names continue using the existing resolution logic.
- Existing integrations require no changes.

## Testing

Tested against a running DCSServerBot instance:

- Global `PlayerCards=true`: HTTP 200 with exactly four fields.
- Server-specific `PlayerCards=true`: HTTP 200 with correctly filtered data.
- `PlayerCards=false`: HTTP 200 with the original 19-field response.
- Parameter omitted: HTTP 200 with the original 19-field response.